### PR TITLE
Add the ability to run the check function against a doc field

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -17,9 +17,65 @@ var flagSchema = new mongoose.Schema({
 
 });
 
+function getValidation( options ){
+    return function profanityCheck( value ) {
+        return (
+            typeof value === 'string' &&
+            ( profanity.check( value, options ).length === 0 )
+        );
+    };
+}
 
-function profanityPlugin (schema, options) {
+function profanityPluginReject2(schema, options) {
+    schema.pre('validate', function ( next ) {
+        var optf = options.fields; //For brevity
+
+        if( optf && Array.isArray( optf ) && optf.length ){
+            var len = optf.length;
+            for( var i = 0; i < len; i++ ){
+                if( !!profanity.check( this[optf[i]], options ).length ){
+                    this.invalidate( optf[i], "Naughy Boi" );
+                    break;
+                }
+            }
+        }
+        next();
+    });
+}
+
+function profanityPluginReject( schema, options ){
+    var optf = options.fields; //For brevity
+
+    if( optf && Array.isArray( optf ) && optf.length ){
+        var len = optf.length;
+        for( var i = 0; i < len; i++ ){
+            var validators = [];
+            var v = schema.paths[optf[i]].validate; //Check if there is already a validation on this field.
+            if ( v ){ //Mongoose allows for a validation function array on a field.
+                if( Array.isArray( v ) ){
+                    validators =  v;
+                } else {
+                    validators.push( v );
+                }
+                validators.push( getValidation( options ) );
+            } else {
+                validators = getValidation( options );
+            }
+            schema.paths[optf[i]].validate = validators;
+        }
+    } else {
+        console.warn( "mongoose-profanity reject option requires a list of schema fields. No profanity filters added!" );
+        return;
+    }
+
+}
+
+function profanityPlugin ( schema, options ) {
     options = options || {};
+
+    if( options.reject ){
+        return profanityPluginReject2( schema, options );
+    }
 
     var flagsToBlacklist = typeof options.maxFlags !== 'undefined' ? options.maxFlags : 3;
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "lib/plugin.js",
   "scripts": {
-    "test": "mocha test"
+    "test": "mocha --timeout 120000 test"
   },
   "repository": {
     "type": "git",
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "mocha": "^3.2.0",
+    "mockgoose": "^7.3.3",
     "should": "^11.1.2"
   }
 }

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -3,21 +3,31 @@ Copyright (C) 2014 Kano Computing Ltd.
 License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
 */
 
-var mongoose = require('mongoose'),
-    profanityPlugin = require('../lib/plugin.js'),
-    should = require('should'),
-    util = require('./util'),
-    Schema = mongoose.Schema;
+var mongoose = require('mongoose');
+
+var Mockgoose = require('mockgoose').Mockgoose;
+
+var mockgoose = new Mockgoose(mongoose);
+ 
+var profanityPlugin = require('../lib/plugin.js');
+
+var should = require('should');
+
+var util = require('./util');
+
+var Schema = mongoose.Schema;
 
 mongoose.Promise = global.Promise;
 
-mongoose.connect('mongodb://localhost/mongooseprofanitytest');
 
-var db = mongoose.connection;
-
-db.on('error', function (err) {
-    console.error('Connection error: please check if mongodb is running on localhost');
-    throw err;
+before( function ( done ) {
+    mockgoose.prepareStorage().then( function () {
+        // mongoose connection		 
+        mongoose.connect( 'mongodb://localhost/mongooseprofanitytest', function ( err ) {
+            console.error( 'Connection error: please check if mongodb is running on localhost' );
+            done( err );
+        });
+    });
 });
 
 var TestSchema = new Schema({


### PR DESCRIPTION
Not a merge request, opening a discussion. 

It turns out the api server has some quirks around its use of mongoose to do the profanity checking at a model level. Here is a solution, but it is temporary in my mind. Hoping for some feedback to close this one tomorrow.